### PR TITLE
Improve GPU switching resilience and reduce D3DImage overhead

### DIFF
--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -1,5 +1,6 @@
 name: publish
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -61,7 +62,14 @@ jobs:
         run: |
           nuget pack ./RenewedVision.Wpf.Interop.DirectX.nuspec -Version ${{ steps.generate-version.outputs.semantic-version }} -Properties "NuGetBinariesWin32=src\Win32\Release;NuGetBinariesX64=src\x64\Release"
 
+      - name: Validate package assets
+        shell: powershell
+        run: |
+          $package = Get-ChildItem . -Filter *.nupkg | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          ./scripts/Test-NuGetPackage.ps1 -PackagePath $package.FullName
+
       - name: Publish Nuget to GitHub registry
+        if: github.event_name == 'push'
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # **WPF DirectX Extensions**
 WPF DirectX Extensions allow you to easily host DirectX 10 and DirectX 11 content in WPF applications.
 
+Supported .NET versions
+-----------------------
+
+The NuGet package contains architecture-specific C++/CLI runtime assemblies for x86 and x64:
+
+| Package target | Supported applications |
+| --- | --- |
+| `net472` | .NET Framework 4.7.2 and later, including 4.8 and 4.8.1 |
+| `net8.0` | .NET 8 WPF |
+| `net9.0` | .NET 9 WPF |
+| `net10.0` | .NET 10 WPF |
+
+Modern .NET C++/CLI binaries are runtime-specific, so each currently supported .NET major version is built as a
+separate project. The `net472` assembly remains the lowest compatible .NET Framework target so newer Framework
+applications can consume the same binary.
+
 Getting Started
 -------------------
  **Where to get it**

--- a/scripts/Test-NuGetPackage.ps1
+++ b/scripts/Test-NuGetPackage.ps1
@@ -1,0 +1,41 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PackagePath
+)
+
+$frameworks = @("net472", "net8.0", "net9.0", "net10.0")
+$runtimeIdentifiers = @("win-x86", "win-x64")
+$expectedEntries = [System.Collections.Generic.List[string]]::new()
+
+foreach ($framework in $frameworks) {
+    $expectedEntries.Add("lib/$framework/RenewedVision.Wpf.Interop.DirectX.dll")
+
+    foreach ($runtimeIdentifier in $runtimeIdentifiers) {
+        $runtimeDirectory = "runtimes/$runtimeIdentifier/lib/$framework"
+        $expectedEntries.Add("$runtimeDirectory/RenewedVision.Wpf.Interop.DirectX.dll")
+        $expectedEntries.Add("$runtimeDirectory/RenewedVision.Wpf.Interop.DirectX.pdb")
+    }
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$resolvedPackagePath = (Resolve-Path -LiteralPath $PackagePath).Path
+$archive = [System.IO.Compression.ZipFile]::OpenRead($resolvedPackagePath)
+
+try {
+    $actualEntries = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($entry in $archive.Entries) {
+        [void] $actualEntries.Add($entry.FullName)
+    }
+
+    $missingEntries = @($expectedEntries | Where-Object { -not $actualEntries.Contains($_) })
+    if ($missingEntries.Count -gt 0) {
+        throw "NuGet package is missing required assets:`n$($missingEntries -join "`n")"
+    }
+}
+finally {
+    $archive.Dispose()
+}
+
+Write-Host "Validated $($expectedEntries.Count) framework and runtime assets in $resolvedPackagePath"

--- a/src/RenewedVision.Wpf.Interop.DirectX/SurfaceQueueInteropHelper.cpp
+++ b/src/RenewedVision.Wpf.Interop.DirectX/SurfaceQueueInteropHelper.cpp
@@ -112,6 +112,7 @@ namespace RenewedVision {
 
 			void SurfaceQueueInteropHelper::CleanupSurfaces()
 			{
+				DetachBackBuffer();
 				m_areSurfacesInitialized = false;
 
 				ReleaseInterface(m_BAProducer);
@@ -121,6 +122,48 @@ namespace RenewedVision {
 
 				ReleaseInterface(m_ABQueue);
 				ReleaseInterface(m_BAQueue);
+			}
+
+			void SurfaceQueueInteropHelper::DetachBackBuffer()
+			{
+				if (nullptr == m_d3dImage || !m_isBackBufferAttached)
+				{
+					return;
+				}
+
+				try
+				{
+					m_d3dImage->Lock();
+					try
+					{
+					m_d3dImage->SetBackBuffer(
+						System::Windows::Interop::D3DResourceType::IDirect3DSurface9, IntPtr::Zero);
+					}
+					finally
+					{
+						m_d3dImage->Unlock();
+					}
+				}
+				catch (Exception^)
+				{
+					// A device can disappear between the availability notification and this call.
+				}
+				finally
+				{
+					m_isBackBufferAttached = false;
+				}
+			}
+
+			void SurfaceQueueInteropHelper::OnFrontBufferAvailableChanged(
+				Object^, DependencyPropertyChangedEventArgs args)
+			{
+				m_shouldSkipRender = !safe_cast<bool>(args.NewValue);
+
+				if (m_shouldSkipRender)
+				{
+					// Software fallback is disabled, so WPF releases its reference when the front buffer is lost.
+					m_isBackBufferAttached = false;
+				}
 			}
 
 			void SurfaceQueueInteropHelper::CleanupD3D()
@@ -245,9 +288,9 @@ namespace RenewedVision {
 
 				if (m_isD3DInitialized)
 				{
-					hr = m_pD3D9Device->CheckDeviceState(NULL);
+					hr = m_D3D10Device->GetDeviceRemovedReason();
 
-					if (D3D_OK != hr)
+					if (FAILED(hr))
 					{
 						CleanupD3D();
 					}
@@ -290,8 +333,6 @@ namespace RenewedVision {
 
 				IDirect3DSurface9* pSurface9 = NULL;
 
-				DXGI_SURFACE_DESC desc;
-
 				// D3D10 portion
 				int count = 0;
 				UINT size = sizeof(int);
@@ -305,18 +346,24 @@ namespace RenewedVision {
 					goto Cleanup;
 				}
 
-				m_d3dImage->Lock();
-				fNeedUnlock = true;
+				try
+				{
+					m_d3dImage->Lock();
+					fNeedUnlock = true;
+				}
+				catch (Exception^)
+				{
+					hr = E_FAIL;
+					goto Cleanup;
+				}
 
 				// Flush the AB queue
-				m_ABProducer->Flush(0 /* wait */, NULL);
+				IFC(m_ABProducer->Flush(0 /* wait */, NULL));
 
 				// Dequeue from AB queue
 				IFC(m_ABConsumer->Dequeue(surfaceIDDXGI, &pUnkDXGISurface, &count, &size, INFINITE));
 
 				IFC(pUnkDXGISurface->QueryInterface(surfaceIDDXGI, (void**)&pDXGISurface));
-
-				IFC(pDXGISurface->GetDesc(&desc));
 
 				if (renderMode == QueueRenderMode::RenderDXGI)
 				{
@@ -332,10 +379,14 @@ namespace RenewedVision {
 				}
 
 				// Produce the surface
-				m_BAProducer->Enqueue(pDXGISurface, NULL, NULL, SURFACE_QUEUE_FLAG_DO_NOT_WAIT);
+				hr = m_BAProducer->Enqueue(pDXGISurface, NULL, NULL, SURFACE_QUEUE_FLAG_DO_NOT_WAIT);
+				if (FAILED(hr) && DXGI_ERROR_WAS_STILL_DRAWING != hr)
+				{
+					goto Cleanup;
+				}
 
 				// Flush the BA queue
-				m_BAProducer->Flush(0 /* wait, *not* SURFACE_QUEUE_FLAG_DO_NOT_WAIT*/, NULL);
+				IFC(m_BAProducer->Flush(0 /* wait, *not* SURFACE_QUEUE_FLAG_DO_NOT_WAIT*/, NULL));
 
 				// Dequeue from BA queue
 				IFC(m_BAConsumer->Dequeue(surfaceID9, &pUnkTexture9, NULL, NULL, INFINITE));
@@ -344,24 +395,60 @@ namespace RenewedVision {
 				// Get the top level surface from the texture
 				IFC(pTexture9->GetSurfaceLevel(0, &pSurface9));
 
-				m_d3dImage->SetBackBuffer(System::Windows::Interop::D3DResourceType::IDirect3DSurface9,
-					(IntPtr)(void*)pSurface9,
-					true // enableSoftwareFallback
-						 // Supports fallback to software rendering for Remote Desktop, etc...
-						 // Was added in WPF 4.5
-				);
+				if (!m_isBackBufferAttached)
+				{
+					try
+					{
+						m_d3dImage->SetBackBuffer(System::Windows::Interop::D3DResourceType::IDirect3DSurface9,
+							(IntPtr)(void*)pSurface9,
+							false // Do not retain a removed-device surface or fall back to an expensive software copy.
+						);
+						m_isBackBufferAttached = true;
+					}
+					catch (Exception^)
+					{
+						hr = E_FAIL;
+						goto Cleanup;
+					}
+				}
 
 				// Produce Surface
-				m_ABProducer->Enqueue(pTexture9, &count, sizeof(int), SURFACE_QUEUE_FLAG_DO_NOT_WAIT);
+				hr = m_ABProducer->Enqueue(pTexture9, &count, sizeof(int), SURFACE_QUEUE_FLAG_DO_NOT_WAIT);
+				if (FAILED(hr) && DXGI_ERROR_WAS_STILL_DRAWING != hr)
+				{
+					goto Cleanup;
+				}
 
 				// Flush the AB queue - use "do not wait" here, we'll block at the top of the *next* call if we need to
-				m_ABProducer->Flush(SURFACE_QUEUE_FLAG_DO_NOT_WAIT, NULL);
+				hr = m_ABProducer->Flush(SURFACE_QUEUE_FLAG_DO_NOT_WAIT, NULL);
+				if (FAILED(hr) && DXGI_ERROR_WAS_STILL_DRAWING != hr)
+				{
+					goto Cleanup;
+				}
+				hr = S_OK;
 
 			Cleanup:
 				if (fNeedUnlock)
 				{
-					m_d3dImage->AddDirtyRect(Int32Rect(0, 0, m_d3dImage->PixelWidth, m_d3dImage->PixelHeight));
-					m_d3dImage->Unlock();
+					try
+					{
+						if (SUCCEEDED(hr) && m_isBackBufferAttached)
+						{
+							m_d3dImage->AddDirtyRect(Int32Rect(0, 0, m_d3dImage->PixelWidth, m_d3dImage->PixelHeight));
+						}
+					}
+					catch (Exception^)
+					{
+						hr = E_FAIL;
+					}
+					try
+					{
+						m_d3dImage->Unlock();
+					}
+					catch (Exception^)
+					{
+						hr = E_FAIL;
+					}
 				}
 
 				ReleaseInterface(pSurface9);
@@ -371,6 +458,12 @@ namespace RenewedVision {
 
 				ReleaseInterface(pDXGISurface);
 				ReleaseInterface(pUnkDXGISurface);
+
+				if (FAILED(hr))
+				{
+					// Queue and WPF failures can leave ownership indeterminate. Recreate the complete device graph on retry.
+					CleanupD3D();
+				}
 			}
 
 
@@ -381,8 +474,10 @@ namespace RenewedVision {
 				{
 					m_pixelWidth = pixelWidth;
 					m_pixelHeight = pixelHeight;
-					CleanupSurfaces();
-					QueueHelper(QueueRenderMode::RenderDXGI);
+					if (m_areSurfacesInitialized)
+					{
+						CleanupSurfaces();
+					}
 				}
 			}
 
@@ -393,7 +488,12 @@ namespace RenewedVision {
 
 			SurfaceQueueInteropHelper::!SurfaceQueueInteropHelper()
 			{
+				if (nullptr != m_d3dImage && nullptr != m_frontBufferAvailableChanged)
+				{
+					m_d3dImage->IsFrontBufferAvailableChanged -= m_frontBufferAvailableChanged;
+				}
 				CleanupD3D();
+				m_d3dImage = nullptr;
 			}
 
 			SurfaceQueueInteropHelper::~SurfaceQueueInteropHelper()

--- a/src/RenewedVision.Wpf.Interop.DirectX/SurfaceQueueInteropHelper.h
+++ b/src/RenewedVision.Wpf.Interop.DirectX/SurfaceQueueInteropHelper.h
@@ -38,6 +38,7 @@ namespace RenewedVision {
 				bool m_isD3DInitialized;
 				bool m_areSurfacesInitialized;
 				bool m_shouldSkipRender;
+				bool m_isBackBufferAttached;
 
 				// Could hypothetically add additional types
 				enum struct QueueRenderMode
@@ -57,6 +58,10 @@ namespace RenewedVision {
 				void CleanupD3D9();
 
 				void CleanupSurfaces();
+
+				void DetachBackBuffer();
+
+				void OnFrontBufferAvailableChanged(Object^ sender, DependencyPropertyChangedEventArgs args);
 
 				void CleanupD3D();
 
@@ -92,12 +97,23 @@ namespace RenewedVision {
 						{
 							if (nullptr != m_d3dImage)
 							{
-								m_d3dImage->SetBackBuffer(System::Windows::Interop::D3DResourceType::IDirect3DSurface9, (IntPtr)nullptr);
+								m_d3dImage->IsFrontBufferAvailableChanged -= m_frontBufferAvailableChanged;
+								DetachBackBuffer();
 							}
 
 							m_d3dImage = d3dImage;
+							m_shouldSkipRender = nullptr == m_d3dImage || !m_d3dImage->IsFrontBufferAvailable;
 
-							// TODO: Force a rerender...?
+							if (nullptr != m_d3dImage)
+							{
+								if (nullptr == m_frontBufferAvailableChanged)
+								{
+									m_frontBufferAvailableChanged = gcnew DependencyPropertyChangedEventHandler(
+										this, &SurfaceQueueInteropHelper::OnFrontBufferAvailableChanged);
+								}
+
+								m_d3dImage->IsFrontBufferAvailableChanged += m_frontBufferAvailableChanged;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

- recover safely when WPF loses its front buffer or Direct3D reports a removed device
- detach the WPF back buffer before releasing shared surfaces and rebuild the complete device graph after interop failures
- reduce per-frame overhead by removing the D3D9 device-state poll, avoiding repeated `SetBackBuffer` calls, and deferring resize rendering
- validate NuGet x86/x64 assets for .NET Framework 4.7.2+ and every currently supported modern runtime: .NET 8, 9, and 10
- run the build and package checks on pull requests without publishing PR packages

## GPU switching and performance details

The old cleanup path could release a surface while `D3DImage` retained a reference through software fallback. It also ignored several queue failures and continued using partial ownership state. The new path listens for `IsFrontBufferAvailableChanged`, disables software fallback, detaches with `SetBackBuffer(null)` before releasing surfaces, and turns unexpected WPF/queue failures into a retryable full reset.

The queue has one stable surface, so rebinding it every composition frame is unnecessary. The new code binds only after creation, resize, front-buffer restoration, or device reset. It also removes `CheckDeviceState` from the hot path and no longer performs a render synchronously from `SetPixelSize`.

Disabling software fallback is intentional: Remote Desktop or another software-rendered WPF session will pause this image instead of retaining and CPU-copying a GPU surface. This is the safer behavior for adapter removal and the lower-resource path.

## Validation

- Release rebuild of the complete solution for x64: passed
- Release rebuild of the complete solution for Win32: passed
- covered `net472`, `net8.0`, `net9.0`, and `net10.0` C++/CLI projects in both builds
- created a local NuGet package with NuGet 6.14: passed
- validated all 20 expected reference/runtime DLL and PDB assets: passed

## Hardware testing requested

- switch the active GPU while a WPF preview is rendering
- move the host window between displays driven by different adapters
- lock/unlock Windows and exercise display sleep/wake
- compare CPU, GPU copy-engine usage, committed memory, and handle count with 0.9.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WPF rendering stability when the front buffer is unavailable or graphics resources are lost.
  * Added safer recovery from rendering and device errors, reducing failures and unnecessary redraws.
  * Improved handling of back-buffer transitions and display availability changes.

* **Documentation**
  * Documented supported .NET Framework and modern .NET WPF versions, including architecture-specific runtime support.

* **Validation**
  * Added automated checks to verify NuGet packages include the required framework and runtime assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->